### PR TITLE
Create and use an OpenStack NFV orchestration demo user

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'r.luethi@x-ion.de'
 license 'Apache 2.0'
 description 'Installs/Configures OpenStack Tacker'
 long_description 'Installs/Configures OpenStack Tacker'
-version '0.1.0'
+version '0.1.1'
 supports         'ubuntu'
 chef_version '>= 12.1' if respond_to?(:chef_version)
 issues_url       'https://github.com/x-ion-de/cookbook-openstack-nfv-orchestration/issues'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'r.luethi@x-ion.de'
 license 'Apache 2.0'
 description 'Installs/Configures OpenStack Tacker'
 long_description 'Installs/Configures OpenStack Tacker'
-version '0.1.1'
+version '0.1.2'
 supports         'ubuntu'
 chef_version '>= 12.1' if respond_to?(:chef_version)
 issues_url       'https://github.com/x-ion-de/cookbook-openstack-nfv-orchestration/issues'

--- a/recipes/sample-user.rb
+++ b/recipes/sample-user.rb
@@ -1,0 +1,65 @@
+#
+# Cookbook:: openstack-nfv-orchestration
+# Recipe:: sample-user
+#
+# Copyright 2017, x-ion GmbH
+
+require 'uri'
+
+class ::Chef::Recipe
+  include ::Openstack
+end
+
+#------------------------------------------------------------------------------
+# Create sample nfv-orchestration user
+#------------------------------------------------------------------------------
+
+identity_admin_endpoint = admin_endpoint 'identity'
+auth_url = ::URI.decode identity_admin_endpoint.to_s
+tacker_demo_user = 'nfvdemo'
+tacker_demo_pass = get_password 'user', 'nfvdemo'
+
+# admin role needed to use OS::Nova::Flavor when creating vnf
+tacker_demo_role = 'admin'
+
+# Should be demo-project, but we cannot rely on one being there
+tacker_demo_project = 'service'
+
+admin_user = node['openstack']['identity']['admin_user']
+admin_pass = get_password 'user', admin_user
+admin_project = node['openstack']['identity']['admin_project']
+admin_domain = node['openstack']['identity']['admin_domain_name']
+
+connection_params = {
+  openstack_auth_url:     "#{auth_url}/auth/tokens",
+  openstack_username:     admin_user,
+  openstack_api_key:      admin_pass,
+  openstack_project_name: admin_project,
+  openstack_domain_name:  admin_domain,
+}
+
+# Register tacker demo user
+openstack_user tacker_demo_user do
+  project_name tacker_demo_project
+  password tacker_demo_pass
+  connection_params connection_params
+end
+
+# Grant role in project to tacker demo user
+openstack_user tacker_demo_user do
+  role_name tacker_demo_role
+  project_name tacker_demo_project
+  connection_params connection_params
+  action :grant_role
+end
+
+# Do we need advanced service role for tacker_demo_user?
+advanced_services_role = 'advsvc'
+
+# Grant additional role in project
+openstack_user tacker_demo_user do
+  role_name advanced_services_role
+  project_name tacker_demo_project
+  connection_params connection_params
+  action :grant_role
+end

--- a/recipes/vim-sample.rb
+++ b/recipes/vim-sample.rb
@@ -48,7 +48,7 @@ end
 template vim_conf_path do
   owner 'root'
   group 'root'
-  mode 0644
+  mode 0600
   variables(
     tacker_admin_user: demo_user,
     tacker_admin_pass: demo_pass,

--- a/recipes/vnf-sample.rb
+++ b/recipes/vnf-sample.rb
@@ -27,8 +27,8 @@ tackerclient = if File.file?("#{pyenv_dir}/bin/tacker")
                  '/usr/bin/tacker'
                end
 
-service_user = node['openstack']['nfv-orchestration']['conf']['keystone_authtoken']['username']
-service_project_name = node['openstack']['nfv-orchestration']['conf']['keystone_authtoken']['project_name']
+demo_user = 'nfvdemo'
+demo_project = 'service'
 service_domain_name = node['openstack']['nfv-orchestration']['conf']['keystone_authtoken']['user_domain_name']
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Check for port_security extension in ml2_conf.ini
@@ -51,14 +51,14 @@ subnet_name = 'selfservice'
 
 ruby_block 'create private network' do
   block do
-    env = openstack_command_env(service_user, service_project_name,
+    env = openstack_command_env(demo_user, demo_project,
                                 service_domain_name, service_domain_name)
     openstack_command('openstack', ['network', 'create', network_name], env)
   end
   not_if do
     # Check if network already exists (note: test wrong if more than
     # one network with the chosen name already exist)
-    env = openstack_command_env(service_user, service_project_name,
+    env = openstack_command_env(demo_user, demo_project,
                                 service_domain_name, service_domain_name)
     begin
       openstack_command('openstack', ['network', 'show', network_name], env)
@@ -72,7 +72,7 @@ end
 
 ruby_block 'create private subnet' do
   block do
-    env = openstack_command_env(service_user, service_project_name,
+    env = openstack_command_env(demo_user, demo_project,
                                   service_domain_name, service_domain_name)
     openstack_command('openstack', ['subnet', 'create',
                                     '--network', network_name,
@@ -82,7 +82,7 @@ ruby_block 'create private subnet' do
   not_if do
     # Check if subnet already exists (note: test wrong if more than
     # one subnet with the chosen name already exist)
-    env = openstack_command_env(service_user, service_project_name,
+    env = openstack_command_env(demo_user, demo_project,
                                 service_domain_name, service_domain_name)
     begin
       openstack_command('openstack', ['subnet', 'show', subnet_name], env)
@@ -95,7 +95,7 @@ end
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ruby_block 'create vnf' do
   block do
-    env = openstack_command_env(service_user, service_project_name,
+    env = openstack_command_env(demo_user, demo_project,
                                  service_domain_name, service_domain_name)
     vnfd_id = openstack_command(tackerclient,
                                ['vnfd-show', vnfd_name,
@@ -107,7 +107,7 @@ ruby_block 'create vnf' do
   not_if do
     # Check if subnet already exists (note: test wrong if more than
     # one subnet with the chosen name already exist)
-    env = openstack_command_env(service_user, service_project_name,
+    env = openstack_command_env(demo_user, demo_project,
                                 service_domain_name, service_domain_name)
     begin
       openstack_command(tackerclient, ['vnf-show', vnf_name], env)
@@ -121,7 +121,7 @@ end
 ruby_block 'wait for vnf to become active' do
   block do
     loop do
-      env = openstack_command_env(service_user, service_project_name,
+      env = openstack_command_env(demo_user, demo_project,
                                 service_domain_name, service_domain_name)
       begin
         break if openstack_command(tackerclient,

--- a/recipes/vnfd-sample.rb
+++ b/recipes/vnfd-sample.rb
@@ -30,8 +30,8 @@ tackerclient = if File.file?("#{pyenv_dir}/bin/tacker")
                  '/usr/bin/tacker'
                end
 
-service_user = node['openstack']['nfv-orchestration']['conf']['keystone_authtoken']['username']
-service_project_name = node['openstack']['nfv-orchestration']['conf']['keystone_authtoken']['project_name']
+demo_user = 'nfvdemo'
+demo_project = 'service'
 service_domain_name = node['openstack']['nfv-orchestration']['conf']['keystone_authtoken']['user_domain_name']
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 directory config_dir do
@@ -52,7 +52,7 @@ end
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ruby_block 'create vnfd' do
   block do
-    env = openstack_command_env(service_user, service_project_name,
+    env = openstack_command_env(demo_user, demo_project,
                                 service_domain_name, service_domain_name)
     # We need user password for tacker user here
     # (openstack-chef-repo/data_bags/user_passwords/tacker.json)
@@ -62,7 +62,7 @@ ruby_block 'create vnfd' do
   end
   not_if do
     # Check if a vnfd already exists
-    env = openstack_command_env(service_user, service_project_name,
+    env = openstack_command_env(demo_user, demo_project,
                                 service_domain_name, service_domain_name)
     begin
       openstack_command(tackerclient, ['vnfd-show', vnfd_name], env)
@@ -75,7 +75,7 @@ end
 
 ruby_block 'wait for vnfd onboarding' do
   block do
-    env = openstack_command_env(service_user, service_project_name,
+    env = openstack_command_env(demo_user, demo_project,
                               service_domain_name, service_domain_name)
     sleep 1 until openstack_command(tackerclient,
                                     ['vnfd-show', vnfd_name,


### PR DESCRIPTION
Create a separate user (nfvdemo) to execute the sample scripts
(vim-sample, vnfd-sample, vnf-sample). This makes it theoretically
possible to reduce the rights granted to this demo user (a project admin
role, however, is needed to use OS::Nova::Flavor when creating the vnf).

The actual reason that triggered this change was openstack_command_env
(openstack-common cookbook). It looks for the user password in the
user_passwords vault which is not where the tacker (service) user's
password is stored.

Alternative workarounds considered include a) a copy containing the
tacker service secret in the user_passwords vault and b) a replacement
function for openstack_command_env.